### PR TITLE
VCST-4032: Increase default value of MaxGram from 20 to 50

### DIFF
--- a/src/VirtoCommerce.ElasticSearch9.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.ElasticSearch9.Core/ModuleConstants.cs
@@ -34,7 +34,7 @@ public static class ModuleConstants
 
     public const int DefaultIndexTotalFieldsLimit = 1000;
     public const int DefaultMinGram = 1;
-    public const int DefaultMaxGram = 20;
+    public const int DefaultMaxGram = 50;
     public const int DefaultSemanticVectorModelDimensions = 384;
     public const decimal DefaultMinScore = 0.1M;
     public const decimal DefaultBoost = 1.0M;


### PR DESCRIPTION
## Description
feat: Increase default value of MaxGram from 20 to 50

## References
### QA-test:
### Jira-link:
### Artifact URL:
