### PR TITLE
VCST-4456: Add distributed locking around ElasticSearch9 index creation

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -289,7 +289,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4456 #v3.800.35
     with:
       installModules: 'false'
       installCustomModule: 'true'

--- a/src/VirtoCommerce.ElasticSearch9.Data/Services/ElasticSearch9Provider.cs
+++ b/src/VirtoCommerce.ElasticSearch9.Data/Services/ElasticSearch9Provider.cs
@@ -574,6 +574,28 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
         }
     }
 
+    protected virtual async Task<CreateIndexResult> InternalCreateIndexWithLockAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
+    {
+        var semaphore = _createIndexSemaphores.GetOrAdd(documentType, static _ => new SemaphoreSlim(1, 1));
+        var resourceKey = $"{nameof(ElasticSearch9Provider)}:{nameof(InternalCreateIndexWithLockAsync)}:{GetIndexName(documentType)}";
+
+        await semaphore.WaitAsync();
+
+        try
+        {
+            return await _distributedLockService.ExecuteAsync(
+                resourceKey,
+                () => InternalCreateIndexAsync(documentType, documents, parameters),
+                lockTimeout: CreateIndexLockTimeout,
+                tryLockTimeout: CreateIndexTryLockTimeout,
+                retryInterval: CreateIndexRetryInterval);
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+
     protected virtual async Task<CreateIndexResult> InternalCreateIndexAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
     {
         var indexName = GetIndexName(parameters.Reindex, documentType);
@@ -604,28 +626,6 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
             IndexName = indexName,
             ProviderDocuments = providerDocuments,
         };
-    }
-
-    protected virtual async Task<CreateIndexResult> InternalCreateIndexWithLockAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
-    {
-        var semaphore = _createIndexSemaphores.GetOrAdd(documentType, static _ => new SemaphoreSlim(1, 1));
-        var resourceKey = $"{nameof(ElasticSearch9Provider)}:{nameof(InternalCreateIndexWithLockAsync)}:{GetIndexName(documentType)}";
-
-        await semaphore.WaitAsync();
-
-        try
-        {
-            return await _distributedLockService.ExecuteAsync(
-                resourceKey,
-                () => InternalCreateIndexAsync(documentType, documents, parameters),
-                lockTimeout: CreateIndexLockTimeout,
-                tryLockTimeout: CreateIndexTryLockTimeout,
-                retryInterval: CreateIndexRetryInterval);
-        }
-        finally
-        {
-            semaphore.Release();
-        }
     }
 
     protected virtual async Task InternalDeleteAsync(string indexAlias)

--- a/src/VirtoCommerce.ElasticSearch9.Data/Services/ElasticSearch9Provider.cs
+++ b/src/VirtoCommerce.ElasticSearch9.Data/Services/ElasticSearch9Provider.cs
@@ -348,7 +348,7 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
     {
         CheckClientCreated();
 
-        return InternalCreateIndexAsync(documentType, [schema], new IndexingParameters { Reindex = true });
+        return InternalCreateIndexWithLockAsync(documentType, [schema], new IndexingParameters { Reindex = true });
     }
 
     public virtual async Task<SuggestionResponse> GetSuggestionsAsync(string documentType, SuggestionRequest request)
@@ -416,7 +416,7 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
 
     protected virtual async Task<IndexingResult> InternalIndexAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
     {
-        var createIndexResult = await InternalCreateIndexAsync(documentType, documents, parameters);
+        var createIndexResult = await InternalCreateIndexWithLockAsync(documentType, documents, parameters);
 
         var pipelines = new List<string>();
 
@@ -576,37 +576,39 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
 
     protected virtual async Task<CreateIndexResult> InternalCreateIndexAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
     {
-        return await ExecuteWithDocumentTypeLockAsync(documentType, async () =>
+        var indexName = GetIndexName(parameters.Reindex, documentType);
+
+        var mapping = await GetMappingAsync(indexName);
+        var providerFields = new Properties(mapping);
+        var oldFieldsCount = providerFields.Count();
+
+        var providerDocuments = documents.Select(document => _documentConverter.ToProviderDocument(documentType, document, providerFields)).ToList();
+
+        var updateMapping = providerFields.Count() != oldFieldsCount;
+
+        var indexExists = await IndexExistsAsync(indexName);
+
+        if (!indexExists)
         {
-            var indexName = GetIndexName(parameters.Reindex, documentType);
+            var newIndexName = GetIndexName(documentType, GetRandomIndexSuffix());
+            await CreateIndexAsync(documentType, newIndexName, alias: indexName);
+        }
 
-            var mapping = await GetMappingAsync(indexName);
-            var providerFields = new Properties(mapping);
-            var oldFieldsCount = providerFields.Count();
+        if (!indexExists || updateMapping)
+        {
+            await UpdateMappingAsync(documentType, indexName, providerFields);
+        }
 
-            var providerDocuments = documents.Select(document => _documentConverter.ToProviderDocument(documentType, document, providerFields)).ToList();
+        return new CreateIndexResult
+        {
+            IndexName = indexName,
+            ProviderDocuments = providerDocuments,
+        };
+    }
 
-            var updateMapping = providerFields.Count() != oldFieldsCount;
-
-            var indexExists = await IndexExistsAsync(indexName);
-
-            if (!indexExists)
-            {
-                var newIndexName = GetIndexName(documentType, GetRandomIndexSuffix());
-                await CreateIndexAsync(documentType, newIndexName, alias: indexName);
-            }
-
-            if (!indexExists || updateMapping)
-            {
-                await UpdateMappingAsync(documentType, indexName, providerFields);
-            }
-
-            return new CreateIndexResult
-            {
-                IndexName = indexName,
-                ProviderDocuments = providerDocuments,
-            };
-        });
+    protected virtual Task<CreateIndexResult> InternalCreateIndexWithLockAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
+    {
+        return ExecuteWithLockAsync(documentType, () => InternalCreateIndexAsync(documentType, documents, parameters));
     }
 
     protected virtual async Task InternalDeleteAsync(string indexAlias)
@@ -935,7 +937,7 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
         return $"{GetIndexName(documentType)}-{alias}".ToLowerInvariant();
     }
 
-    protected virtual async Task<T> ExecuteWithDocumentTypeLockAsync<T>(string documentType, Func<Task<T>> resolver)
+    protected virtual async Task<T> ExecuteWithLockAsync<T>(string documentType, Func<Task<T>> resolver)
     {
         var semaphore = _createIndexSemaphores.GetOrAdd(documentType, static _ => new SemaphoreSlim(1, 1));
 

--- a/src/VirtoCommerce.ElasticSearch9.Data/Services/ElasticSearch9Provider.cs
+++ b/src/VirtoCommerce.ElasticSearch9.Data/Services/ElasticSearch9Provider.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Analysis;
@@ -21,6 +22,7 @@ using VirtoCommerce.ElasticSearch9.Core.Models;
 using VirtoCommerce.ElasticSearch9.Core.Services;
 using VirtoCommerce.ElasticSearch9.Data.Extensions;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.DistributedLock;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.SearchModule.Core.Exceptions;
 using VirtoCommerce.SearchModule.Core.Model;
@@ -37,10 +39,15 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
     private readonly IElasticSearchDocumentConverter _documentConverter;
     private readonly ILogger<ElasticSearch9Provider> _logger;
     private readonly IElasticSearchPropertyService _propertyService;
+    private readonly IDistributedLockService _distributedLockService;
 
     private readonly ConcurrentDictionary<string, IDictionary<PropertyName, IProperty>> _mappings = new();
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _createIndexSemaphores = new(StringComparer.OrdinalIgnoreCase);
 
     private const int SuffixLength = 10;
+    private static readonly TimeSpan CreateIndexLockTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan CreateIndexTryLockTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan CreateIndexRetryInterval = TimeSpan.FromMilliseconds(200);
 
     protected ElasticsearchClient Client { get; }
     protected Uri ServerUrl { get; }
@@ -60,7 +67,8 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
         IElasticSearchResponseBuilder searchResponseBuilder,
         IElasticSearchDocumentConverter documentConverter,
         ILogger<ElasticSearch9Provider> logger,
-        IElasticSearchPropertyService propertyService
+        IElasticSearchPropertyService propertyService,
+        IDistributedLockService distributedLockService
     )
     {
         _searchOptions = searchOptions.Value;
@@ -70,6 +78,7 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
         _documentConverter = documentConverter;
         _logger = logger;
         _propertyService = propertyService;
+        _distributedLockService = distributedLockService;
 
         if (!string.IsNullOrEmpty(elasticOptions.Value.Server))
         {
@@ -567,34 +576,37 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
 
     protected virtual async Task<CreateIndexResult> InternalCreateIndexAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
     {
-        var indexName = GetIndexName(parameters.Reindex, documentType);
-
-        var mapping = await GetMappingAsync(indexName);
-        var providerFields = new Properties(mapping);
-        var oldFieldsCount = providerFields.Count();
-
-        var providerDocuments = documents.Select(document => _documentConverter.ToProviderDocument(documentType, document, providerFields)).ToList();
-
-        var updateMapping = providerFields.Count() != oldFieldsCount;
-
-        var indexExists = await IndexExistsAsync(indexName);
-
-        if (!indexExists)
+        return await ExecuteWithDocumentTypeLockAsync(documentType, async () =>
         {
-            var newIndexName = GetIndexName(documentType, GetRandomIndexSuffix());
-            await CreateIndexAsync(documentType, newIndexName, alias: indexName);
-        }
+            var indexName = GetIndexName(parameters.Reindex, documentType);
 
-        if (!indexExists || updateMapping)
-        {
-            await UpdateMappingAsync(documentType, indexName, providerFields);
-        }
+            var mapping = await GetMappingAsync(indexName);
+            var providerFields = new Properties(mapping);
+            var oldFieldsCount = providerFields.Count();
 
-        return new CreateIndexResult
-        {
-            IndexName = indexName,
-            ProviderDocuments = providerDocuments,
-        };
+            var providerDocuments = documents.Select(document => _documentConverter.ToProviderDocument(documentType, document, providerFields)).ToList();
+
+            var updateMapping = providerFields.Count() != oldFieldsCount;
+
+            var indexExists = await IndexExistsAsync(indexName);
+
+            if (!indexExists)
+            {
+                var newIndexName = GetIndexName(documentType, GetRandomIndexSuffix());
+                await CreateIndexAsync(documentType, newIndexName, alias: indexName);
+            }
+
+            if (!indexExists || updateMapping)
+            {
+                await UpdateMappingAsync(documentType, indexName, providerFields);
+            }
+
+            return new CreateIndexResult
+            {
+                IndexName = indexName,
+                ProviderDocuments = providerDocuments,
+            };
+        });
     }
 
     protected virtual async Task InternalDeleteAsync(string indexAlias)
@@ -921,6 +933,32 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
     protected virtual string GetIndexAlias(string alias, string documentType)
     {
         return $"{GetIndexName(documentType)}-{alias}".ToLowerInvariant();
+    }
+
+    protected virtual async Task<T> ExecuteWithDocumentTypeLockAsync<T>(string documentType, Func<Task<T>> resolver)
+    {
+        var semaphore = _createIndexSemaphores.GetOrAdd(documentType, static _ => new SemaphoreSlim(1, 1));
+
+        await semaphore.WaitAsync();
+
+        try
+        {
+            return await _distributedLockService.ExecuteAsync(
+                GetCreateIndexLockResourceKey(documentType),
+                resolver,
+                lockTimeout: CreateIndexLockTimeout,
+                tryLockTimeout: CreateIndexTryLockTimeout,
+                retryInterval: CreateIndexRetryInterval);
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+
+    protected virtual string GetCreateIndexLockResourceKey(string documentType)
+    {
+        return $"{nameof(ElasticSearch9Provider)}:CreateIndex:{GetIndexName(documentType)}";
     }
 
     /// <summary>

--- a/src/VirtoCommerce.ElasticSearch9.Data/Services/ElasticSearch9Provider.cs
+++ b/src/VirtoCommerce.ElasticSearch9.Data/Services/ElasticSearch9Provider.cs
@@ -606,9 +606,26 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
         };
     }
 
-    protected virtual Task<CreateIndexResult> InternalCreateIndexWithLockAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
+    protected virtual async Task<CreateIndexResult> InternalCreateIndexWithLockAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
     {
-        return ExecuteWithLockAsync(documentType, () => InternalCreateIndexAsync(documentType, documents, parameters));
+        var semaphore = _createIndexSemaphores.GetOrAdd(documentType, static _ => new SemaphoreSlim(1, 1));
+        var resourceKey = $"{nameof(ElasticSearch9Provider)}:{nameof(InternalCreateIndexWithLockAsync)}:{GetIndexName(documentType)}";
+
+        await semaphore.WaitAsync();
+
+        try
+        {
+            return await _distributedLockService.ExecuteAsync(
+                resourceKey,
+                () => InternalCreateIndexAsync(documentType, documents, parameters),
+                lockTimeout: CreateIndexLockTimeout,
+                tryLockTimeout: CreateIndexTryLockTimeout,
+                retryInterval: CreateIndexRetryInterval);
+        }
+        finally
+        {
+            semaphore.Release();
+        }
     }
 
     protected virtual async Task InternalDeleteAsync(string indexAlias)
@@ -935,32 +952,6 @@ public partial class ElasticSearch9Provider : ISearchProvider, ISupportIndexSwap
     protected virtual string GetIndexAlias(string alias, string documentType)
     {
         return $"{GetIndexName(documentType)}-{alias}".ToLowerInvariant();
-    }
-
-    protected virtual async Task<T> ExecuteWithLockAsync<T>(string documentType, Func<Task<T>> resolver)
-    {
-        var semaphore = _createIndexSemaphores.GetOrAdd(documentType, static _ => new SemaphoreSlim(1, 1));
-
-        await semaphore.WaitAsync();
-
-        try
-        {
-            return await _distributedLockService.ExecuteAsync(
-                GetCreateIndexLockResourceKey(documentType),
-                resolver,
-                lockTimeout: CreateIndexLockTimeout,
-                tryLockTimeout: CreateIndexTryLockTimeout,
-                retryInterval: CreateIndexRetryInterval);
-        }
-        finally
-        {
-            semaphore.Release();
-        }
-    }
-
-    protected virtual string GetCreateIndexLockResourceKey(string documentType)
-    {
-        return $"{nameof(ElasticSearch9Provider)}:CreateIndex:{GetIndexName(documentType)}";
     }
 
     /// <summary>

--- a/tests/VirtoCommerce.ElasticSearch9.Tests/Integration/ElasticSearch9Tests.cs
+++ b/tests/VirtoCommerce.ElasticSearch9.Tests/Integration/ElasticSearch9Tests.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.ElasticSearch9.Core.Models;
 using VirtoCommerce.ElasticSearch9.Data.Services;
+using VirtoCommerce.Platform.Core.DistributedLock;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
 using Xunit;
@@ -50,9 +53,23 @@ public class ElasticSearch9Tests : SearchProviderTests
             responseBuilder,
             documentConverter,
             providerLogger,
-            propertyService
+            propertyService,
+            new NoLockService()
             );
 
         return provider;
+    }
+
+    private sealed class NoLockService : IDistributedLockService
+    {
+        public T Execute<T>(string resourceKey, Func<T> resolver, TimeSpan? lockTimeout = null, TimeSpan? tryLockTimeout = null, TimeSpan? retryInterval = null, CancellationToken? cancellationToken = null)
+        {
+            return resolver();
+        }
+
+        public Task<T> ExecuteAsync<T>(string resourceKey, Func<Task<T>> resolver, TimeSpan? lockTimeout = null, TimeSpan? tryLockTimeout = null, TimeSpan? retryInterval = null, CancellationToken? cancellationToken = null)
+        {
+            return resolver();
+        }
     }
 }

--- a/tests/VirtoCommerce.ElasticSearch9.Tests/Unit/ElasticSearch9ProviderCreateIndexLockTests.cs
+++ b/tests/VirtoCommerce.ElasticSearch9.Tests/Unit/ElasticSearch9ProviderCreateIndexLockTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Mapping;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.ElasticSearch9.Core.Models;
+using VirtoCommerce.ElasticSearch9.Core.Services;
+using VirtoCommerce.ElasticSearch9.Data.Services;
+using VirtoCommerce.Platform.Core.DistributedLock;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.SearchModule.Core.Model;
+using Xunit;
+
+namespace VirtoCommerce.ElasticSearch9.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public class ElasticSearch9ProviderCreateIndexLockTests
+{
+    [Fact]
+    public async Task InternalCreateIndexWithLockAsync_PreventsDuplicateIndexCreation()
+    {
+        // Arrange
+        var indexStoreWithoutLock = new IndexStore(new Barrier(2));
+        var providerWithoutLock = new TestElasticSearch9Provider(indexStoreWithoutLock);
+
+        // Act
+        await Task.WhenAll(
+            providerWithoutLock.CallInternalCreateIndexAsync(),
+            providerWithoutLock.CallInternalCreateIndexAsync());
+
+        // Assert
+        indexStoreWithoutLock.CreatedIndexCount.Should().Be(2, "without a lock both calls pass the index existence check before the index is created");
+
+        var indexStoreWithLock = new IndexStore();
+        var providerWithLock = new TestElasticSearch9Provider(indexStoreWithLock);
+
+        await Task.WhenAll(
+            providerWithLock.CallInternalCreateIndexWithLockAsync(),
+            providerWithLock.CallInternalCreateIndexWithLockAsync());
+
+        indexStoreWithLock.CreatedIndexCount.Should().Be(1, "the lock should serialize index creation and prevent duplicate indexes");
+    }
+
+    private sealed class TestElasticSearch9Provider(IndexStore indexStore) : ElasticSearch9Provider(
+        Options.Create(new SearchOptions { Scope = "test-core", Provider = "ElasticSearch9" }),
+        Options.Create(new ElasticSearch9Options()),
+        Mock.Of<ISettingsManager>(),
+        Mock.Of<IElasticSearchRequestBuilder>(),
+        Mock.Of<IElasticSearchResponseBuilder>(),
+        Mock.Of<IElasticSearchDocumentConverter>(),
+        Mock.Of<ILogger<ElasticSearch9Provider>>(),
+        Mock.Of<IElasticSearchPropertyService>(),
+        new PassThroughDistributedLockService())
+    {
+        private const string DocumentType = "Product";
+
+        public Task CallInternalCreateIndexAsync() => InternalCreateIndexAsync(DocumentType, [], new IndexingParameters());
+
+        public Task CallInternalCreateIndexWithLockAsync() => InternalCreateIndexWithLockAsync(DocumentType, [], new IndexingParameters());
+
+        protected override Task<IDictionary<PropertyName, IProperty>> GetMappingAsync(string indexName) => Task.FromResult<IDictionary<PropertyName, IProperty>>(new Dictionary<PropertyName, IProperty>());
+
+        protected override Task<bool> IndexExistsAsync(string indexName) => indexStore.IndexExistsAsync();
+
+        protected override Task CreateIndexAsync(string documentType, string indexName, string alias)
+        {
+            indexStore.CreateIndex();
+
+            return Task.CompletedTask;
+        }
+
+        protected override Task UpdateMappingAsync(string documentType, string indexName, Properties properties) => Task.CompletedTask;
+    }
+
+    private sealed class IndexStore(Barrier indexExistsBarrier = null)
+    {
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+        private int _createdIndexCount;
+
+        public int CreatedIndexCount => Volatile.Read(ref _createdIndexCount);
+
+        public async Task<bool> IndexExistsAsync()
+        {
+            var indexExists = CreatedIndexCount > 0;
+            await Task.Yield();
+            indexExistsBarrier?.SignalAndWait(Timeout);
+
+            return indexExists;
+        }
+
+        public void CreateIndex() => Interlocked.Increment(ref _createdIndexCount);
+    }
+
+    private sealed class PassThroughDistributedLockService : IDistributedLockService
+    {
+        public T Execute<T>(string resourceKey, Func<T> resolver, TimeSpan? lockTimeout = null, TimeSpan? tryLockTimeout = null, TimeSpan? retryInterval = null, CancellationToken? cancellationToken = null) => resolver();
+
+        public Task<T> ExecuteAsync<T>(string resourceKey, Func<Task<T>> resolver, TimeSpan? lockTimeout = null, TimeSpan? tryLockTimeout = null, TimeSpan? retryInterval = null, CancellationToken? cancellationToken = null) => resolver();
+    }
+}


### PR DESCRIPTION
## Description
Added distributed locking for ElasticSearch9 index creation by injecting IDistributedLockService, wrapping index creation and mapping updates in a per-document-type distributed lock with a local semaphore, and updating integration test setup with a no-op lock service.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4456
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch9_3.1003.0-pr-14-7eb4.zip